### PR TITLE
投稿一覧&フォーム画面取得処理のテストを追加

### DIFF
--- a/src/laravel/app/Dto/GetListAndFormServiceDto.php
+++ b/src/laravel/app/Dto/GetListAndFormServiceDto.php
@@ -6,35 +6,18 @@ use App\Entity\Post;
 use App\Entity\Tag;
 use App\Entity\User;
 
-class GetListAndFormServiceDto
+readonly class GetListAndFormServiceDto
 {
-    public readonly User $user;
-
-    /** @var Post[] */
-    public readonly array $posts;
-
-    /** @var array{int: Image[] | array} */
-    public readonly array $images;
-
-    /** @var array{int: Tag[] | array} */
-    public readonly array $tags;
-
     /**
      * @param User $user
-     * @param array $posts
+     * @param Post[] $posts
      * @param array{int: Image[] | array} $images
      * @param array{int: Tag[] | array} $tags
      */
     function __construct(
-        User $user,
-        array $posts,
-        array $images,
-        array $tags,
-    )
-    {
-        $this->user = $user;
-        $this->posts = $posts;
-        $this->images = $images;
-        $this->tags = $tags;
-    }
+        public User $user,
+        public array $posts,
+        public array $images,
+        public array $tags,
+    ){}
 }

--- a/src/laravel/app/Providers/RepositoriesServiceProvaider.php
+++ b/src/laravel/app/Providers/RepositoriesServiceProvaider.php
@@ -8,7 +8,7 @@ use App\Repositries\Posts\PostRepository;
 use App\Repositries\Posts\PostRepositoryInterface;
 use App\Repositries\Tags\TagRepository;
 use App\Repositries\Tags\TagrepositoryInterface;
-use App\Repositries\User\UserRepoInterface;
+use App\Repositries\User\UserRepositoryInterface;
 use App\Repositries\User\UserRepository;
 use Illuminate\Support\ServiceProvider;
 
@@ -20,7 +20,7 @@ class RepositoriesServiceProvaider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(
-            UserRepoInterface::class,
+            UserRepositoryInterface::class,
             UserRepository::class
         );
 

--- a/src/laravel/app/Providers/ServicesServiceProvaider.php
+++ b/src/laravel/app/Providers/ServicesServiceProvaider.php
@@ -5,7 +5,7 @@ namespace App\Providers;
 use App\Repositries\Posts\ImageRepositoryInterface;
 use App\Repositries\Posts\PostRepositoryInterface;
 use App\Repositries\Tags\TagrepositoryInterface;
-use App\Repositries\User\UserRepoInterface;
+use App\Repositries\User\UserRepositoryInterface;
 use App\Services\Posts\GetListAndFormServiceInterface;
 use App\Services\Posts\GetListAndFormService;
 use App\Services\User\CreateNewUserService;
@@ -23,14 +23,14 @@ class ServicesServiceProvaider extends ServiceProvider
             CreateNewUserServiceInterface::class,
             function ($app) {
                 return new CreateNewUserService(
-                    $app->make(UserRepoInterface::class),
+                    $app->make(UserRepositoryInterface::class),
                 );
             });
 
         $this->app->bind(GetListAndFormServiceInterface::class,
             function ($app){
                 return new GetListAndFormService(
-                    $app->make(UserRepoInterface::class),
+                    $app->make(UserRepositoryInterface::class),
                     $app->make(PostRepositoryInterface::class),
                     $app->make(ImageRepositoryInterface::class),
                     $app->make(TagrepositoryInterface::class),

--- a/src/laravel/app/Repositries/User/UserRepository.php
+++ b/src/laravel/app/Repositries/User/UserRepository.php
@@ -3,7 +3,7 @@ namespace App\Repositries\User;
 
 use App\Models\User;
 
-class UserRepository implements UserRepoInterface
+class UserRepository implements UserRepositoryInterface
 {
     /**
      * @param \App\Entity\User $user

--- a/src/laravel/app/Repositries/User/UserRepositoryInterface.php
+++ b/src/laravel/app/Repositries/User/UserRepositoryInterface.php
@@ -3,7 +3,7 @@ namespace App\Repositries\User;
 
 use App\Models\User;
 
-interface UserRepoInterface
+interface UserRepositoryInterface
 {
     public function create(\App\Entity\User $user): User;
 }

--- a/src/laravel/app/Services/Posts/GetListAndFormService.php
+++ b/src/laravel/app/Services/Posts/GetListAndFormService.php
@@ -8,24 +8,24 @@ use App\Repositries\Posts\ImageRepositoryInterface;
 use App\Repositries\Posts\PostRepositoryInterface;
 use App\Repositries\Tags\TagRepository;
 use App\Repositries\Tags\TagrepositoryInterface;
-use App\Repositries\User\UserRepoInterface;
+use App\Repositries\User\UserRepositoryInterface;
 use Illuminate\Support\Facades\Auth;
 
 class GetListAndFormService implements GetListAndFormServiceInterface
 {
-    private readonly UserRepoInterface $userRepo;
+    private readonly UserRepositoryInterface $userRepository;
     private readonly PostRepositoryInterface $postRepository;
     private readonly ImageRepositoryInterface $imageRepository;
     private readonly TagrepositoryInterface $tagrepository;
     public function __construct(
-        UserRepoInterface $userRepo,
-        PostRepositoryInterface $postRepository,
+        UserRepositoryInterface  $userRepository,
+        PostRepositoryInterface  $postRepository,
         ImageRepositoryInterface $imageRepository,
-        TagRepository $tagrepository
+        TagRepository            $tagrepository
     )
     {
         $this->postRepository = $postRepository;
-        $this->userRepo = $userRepo;
+        $this->userRepository = $userRepository;
         $this->imageRepository = $imageRepository;
         $this->tagrepository = $tagrepository;
     }
@@ -33,7 +33,7 @@ class GetListAndFormService implements GetListAndFormServiceInterface
 
     public function run(): GetListAndFormServiceDto
     {
-        $user = $this->userRepo->find(Auth::id());
+        $user = $this->userRepository->find(Auth::id());
 
         $posts = $this->postRepository->getAll();
 

--- a/src/laravel/app/Services/User/CreateNewUserService.php
+++ b/src/laravel/app/Services/User/CreateNewUserService.php
@@ -3,16 +3,16 @@ declare(strict_types=1);
 namespace App\Services\User;
 
 use App\Models\User;
-use App\Repositries\User\UserRepoInterface;
+use App\Repositries\User\UserRepositoryInterface;
 use App\Services\StoreFileService;
 
 class CreateNewUserService implements CreateNewUserServiceInterface
 {
-    private readonly UserRepoInterface $userRepo;
+    private readonly UserRepositoryInterface $userRepository;
 
-    public function __construct(UserRepoInterface $userRepo)
+    public function __construct(UserRepositoryInterface $userRepository)
     {
-        $this->userRepo = $userRepo;
+        $this->userRepository = $userRepository;
     }
 
     /**
@@ -25,7 +25,7 @@ class CreateNewUserService implements CreateNewUserServiceInterface
         $profile_image_url = StoreFileService::run($input['profile-image']);
 
         try {
-            return $this->userRepo->create(User::buildValidatedUserParams(
+            return $this->userRepository->create(User::buildValidatedUserParams(
                 name: $input['name'],
                 email: $input['email'],
                 password: $input['password'],

--- a/src/laravel/database/factories/ImageFactory.php
+++ b/src/laravel/database/factories/ImageFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Image>
+ */
+class ImageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'image_url' => 'public/image/user_profile' . fake()->name . '.png',
+            'post_id' => Post::factory(),
+        ];
+    }
+
+    public function specifyPost_id(int $post_id)
+    {
+        return $this->state(fn () => [
+           'post_id' => $post_id,
+        ]);
+    }
+}

--- a/src/laravel/database/factories/ImageFactory.php
+++ b/src/laravel/database/factories/ImageFactory.php
@@ -18,7 +18,7 @@ class ImageFactory extends Factory
     public function definition(): array
     {
         return [
-            'image_url' => 'public/image/user_profile' . fake()->name . '.png',
+            'image_url' => '/public/image/posts/' . fake()->name . '.png',
             'post_id' => Post::factory(),
         ];
     }

--- a/src/laravel/database/factories/PostFactory.php
+++ b/src/laravel/database/factories/PostFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -17,10 +18,10 @@ class PostFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => 'test',
-            'content' => 'test',
-            'thumnail_url' => 'public',
-            'user_id' => 1,
+            'title' => fake()->title,
+            'content' => fake()->text,
+            'thumnail_url' => 'public/image/user_profile/fkeoafjpfr.png',
+            'user_id' => User::factory(),
         ];
     }
 }

--- a/src/laravel/database/factories/TagFactory.php
+++ b/src/laravel/database/factories/TagFactory.php
@@ -20,17 +20,10 @@ class TagFactory extends Factory
         ];
     }
 
-    public function nameIs総合()
+    public function specifyName(string $name)
     {
         return $this->state(fn () => [
-           'name' => '総合',
-        ]);
-    }
-
-    public function nameIsテクノロジー()
-    {
-        return $this->state(fn () => [
-            'name' => 'テクノロジー',
+           'name' => $name,
         ]);
     }
 }

--- a/src/laravel/database/factories/TagFactory.php
+++ b/src/laravel/database/factories/TagFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ */
+class TagFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+        ];
+    }
+
+    public function nameIs総合()
+    {
+        return $this->state(fn () => [
+           'name' => '総合',
+        ]);
+    }
+
+    public function nameIsテクノロジー()
+    {
+        return $this->state(fn () => [
+            'name' => 'テクノロジー',
+        ]);
+    }
+}

--- a/src/laravel/database/seeders/TestPostTagSeeder.php
+++ b/src/laravel/database/seeders/TestPostTagSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TestPostTagSeeder extends Seeder
+{
+    /**
+     * @param int $post_id
+     * @param int $tag_id
+     */
+    public function run(int $post_id, int $tag_id): void
+    {
+        DB::table('post_tag')->insert([
+            'post_id' => $post_id,
+            'tag_id' => $tag_id,
+        ]);
+    }
+}

--- a/src/laravel/tests/Unit/Posts/GetListAndFormTest.php
+++ b/src/laravel/tests/Unit/Posts/GetListAndFormTest.php
@@ -15,6 +15,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertTrue;
 
 class GetListAndFormTest extends TestCase
 {
@@ -50,6 +51,16 @@ class GetListAndFormTest extends TestCase
         $this->assertSame($testImageCollection->id, $images[0]->id);
     }
 
+    public function test_imageRepository_findFromPost__画像を持たない記事のidが渡された時、空の配列を取得できること()
+    {
+        $testPostCollection = PostFactory::new()->create();
+        $imageRepository = new ImageRepository();
+
+        $image = $imageRepository->findFromPost($testPostCollection->id);
+
+        assertTrue(empty($image));
+    }
+
     #[DataProvider('tagByPostDataProvider')]
     public function test_tagRepository_findFromPost__タグを持つ記事のidが渡された時、期待したタグを取得できること(string $expected_tag_name)
     {
@@ -64,6 +75,16 @@ class GetListAndFormTest extends TestCase
         $tag = $testRepository->findFromPost($testPostCollection->id);
 
         assertSame($expected_tag_name, $tag[0]->name);
+    }
+
+    public function test_tagRepository_findFromPost__タグを持たない記事のidが渡された時、空の配列を取得できること()
+    {
+        $testPostCollection = PostFactory::new()->create();
+        $tagRepository = new TagRepository();
+
+        $tag = $tagRepository->findFromPost($testPostCollection->id);
+
+        assertTrue(empty($tag));
     }
 
     public static function tagByPostDataProvider():array

--- a/src/laravel/tests/Unit/Posts/GetListAndFormTest.php
+++ b/src/laravel/tests/Unit/Posts/GetListAndFormTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace App\tests\Unit\Posts;
+
+use App\Models\Post;
+use App\Repositries\Posts\ImageRepository;
+use App\Repositries\Posts\PostRepository;
+use App\Repositries\Tags\TagRepository;
+use App\Repositries\User\UserRepository;
+use Database\Factories\ImageFactory;
+use Database\Factories\PostFactory;
+use Database\Factories\TagFactory;
+use Database\Factories\UserFactory;
+use Database\Seeders\TestPostTagSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use function PHPUnit\Framework\assertSame;
+
+class GetListAndFormTest extends TestCase
+{
+    use RefreshDatabase;
+    public function test_userRepo_find__期待したユーザを取得できること()
+    {
+        $testUserCollection = UserFactory::new()->create();
+        $userRepository = new UserRepository();
+
+        $user = $userRepository->find($testUserCollection->id);
+
+        //nameは一意制約を持っているため取得したデータで名前が期待したものなら、期待したユーザとします
+        assertSame($testUserCollection->name, $user->name);
+    }
+
+    public function test_postRepository_getAll__記事を全件取得できること()
+    {
+        PostFactory::new()->count(5)->create();
+
+        $postRepository = new PostRepository;
+        $post = $postRepository->getAll();
+
+        self::assertCount(5, $post);
+    }
+
+    public function test_imageRepository_findFromPost__画像を持つ記事のidが渡された時、期待した画像を取得できること()
+    {
+        $testPostCollection = Post::factory(3)->create();
+        $imageRepository = new ImageRepository;
+
+        foreach ($testPostCollection as $testPost){
+            $testImageCollection = ImageFactory::new()->specifyPost_id($testPost->id)->count(2)->create();
+
+            $images = $imageRepository->findFromPost($testPost->id);
+
+            foreach ($images as $key => $image){
+                assertSame($testImageCollection[$key]->id, $image->id);
+            }
+        }
+    }
+
+    public function test_tagRepository_findFromPost__タグを持つ記事のidが渡された時、期待したタグを取得できること()
+    {
+        $testPostCollection = PostFactory::new()->count(3)->create();
+        $testTagNameIs総合 = TagFactory::new()->nameIs総合()->create();
+        $testTagNameIsテクノロジー = TagFactory::new()->nameIsテクノロジー()->create();
+        //postsとtagsの中間テーブルにテストデータを挿入する
+        $testPostTagSeeder = new TestPostTagSeeder;
+        $testRepository = new TagRepository;
+
+        foreach ($testPostCollection as $testPost){
+            $testPostTagSeeder->run($testPost->id, $testTagNameIs総合->id);
+            $testPostTagSeeder->run($testPost->id, $testTagNameIsテクノロジー->id);
+
+            $tags = $testRepository->findFromPost($testPost->id);
+
+            assertSame($testTagNameIs総合->name, $tags[0]->name);
+            assertSame($testTagNameIsテクノロジー->name, $tags[1]->name);
+        }
+    }
+}

--- a/src/laravel/tests/Unit/Posts/GetListAndFormTest.php
+++ b/src/laravel/tests/Unit/Posts/GetListAndFormTest.php
@@ -49,8 +49,8 @@ class GetListAndFormTest extends TestCase
 
             $images = $imageRepository->findFromPost($testPost->id);
 
-            foreach ($images as $key => $image){
-                assertSame($testImageCollection[$key]->id, $image->id);
+            foreach ($images as $index => $image){
+                assertSame($testImageCollection[$index]->id, $image->id);
             }
         }
     }

--- a/src/laravel/tests/Unit/Posts/GetListAndFormTest.php
+++ b/src/laravel/tests/Unit/Posts/GetListAndFormTest.php
@@ -18,7 +18,7 @@ use function PHPUnit\Framework\assertSame;
 class GetListAndFormTest extends TestCase
 {
     use RefreshDatabase;
-    public function test_userRepo_find__期待したユーザを取得できること()
+    public function test_userRepository_find__期待したユーザを取得できること()
     {
         $testUserCollection = UserFactory::new()->create();
         $userRepository = new UserRepository();


### PR DESCRIPTION
# 変更内容
- ユーザ、記事、画像、タグについてそれぞDBから期待したものが取得できているかのテストを実装しました
- 今回中間テーブルのモデルは作成していないため、中間テーブルのデータ作成はFactoryからではなくSeederとしてテスト実行時に呼び出しています
- 一部名前変更とreadonly classに変更しています